### PR TITLE
Add optional search_path parameter

### DIFF
--- a/db/connection.go
+++ b/db/connection.go
@@ -119,7 +119,7 @@ func (db PG) connectionString() string {
 		password = ":" + password
 	}
 
-	return fmt.Sprintf(
+	connString := fmt.Sprintf(
 		"postgres://%s%s@%s:%s/%s?sslmode=%s",
 		env.GetString("DB_USER", "postgres"),
 		password,
@@ -128,6 +128,12 @@ func (db PG) connectionString() string {
 		env.MustGetString("DB_NAME"),
 		env.GetString("DB_SSL_MODE", "disable"),
 	)
+
+	searchPath := env.GetString("DB_SEARCH_PATH", "")
+	if len(searchPath) > 0 {
+		connString = fmt.Sprintf("%s&search_path=%s", connString, searchPath)
+	}
+	return connString
 }
 
 // logSafeConnectionString is the database connection string with the password replace with `****` so it can be logged

--- a/db/connection_internal_test.go
+++ b/db/connection_internal_test.go
@@ -15,6 +15,31 @@ var _ = Describe("PG", func() {
 		os.Setenv("DB_PORT", "5432")
 		os.Setenv("DB_PASSWORD", "password")
 		os.Setenv("DB_SSL_MODE", "disable")
+		os.Setenv("DB_SEARCH_PATH", "public")
+
+		Context("when there is a search path", func() {
+			It("adds the search_path parameter", func() {
+				db := PG{}
+
+				actual := db.logSafeConnectionString()
+				expected := "postgres://user:****@host:5432/test?sslmode=disable&search_path=public"
+
+				Expect(actual).To(Equal(expected))
+			})
+		})
+
+		Context("when there is no search path", func() {
+			It("leaves the connection string as is", func() {
+				os.Setenv("DB_SEARCH_PATH", "")
+
+				db := PG{}
+
+				actual := db.logSafeConnectionString()
+				expected := "postgres://user:****@host:5432/test?sslmode=disable"
+
+				Expect(actual).To(Equal(expected))
+			})
+		})
 
 		Context("when there is a password", func() {
 			It("replaces the password with stars", func() {


### PR DESCRIPTION
Adds a search_path parameter for DB connections.

https://www.postgresql.org/docs/8.1/static/ddl-schemas.html#DDL-SCHEMAS-PATH