### PR TITLE
Remove closure of subscribe thread

### DIFF
--- a/redis/subscribe.go
+++ b/redis/subscribe.go
@@ -10,7 +10,6 @@ import (
 // Subscribe will block forever, so a goroutine is recommended
 func (c Cache) Subscribe(subscription string, handleResponse func(interface{}) ) {
 	conn := c.Conn()
-	defer conn.Close()
 
 	_, err := conn.Do("PSUBSCRIBE", subscription)
 	if err != nil {


### PR DESCRIPTION
Fixes a race condition which results in a redis only returning nil data