### PR TITLE
Add elasticsearch and geo packages

### DIFF
--- a/elasticsearch/connection.go
+++ b/elasticsearch/connection.go
@@ -1,0 +1,28 @@
+package elasticsearch
+
+import (
+	"sync"
+
+	"github.com/olivere/elastic"
+)
+
+var (
+	conn     *elastic.Client
+	initOnce = sync.Once{}
+)
+
+func initConn() {
+	// Create a client
+	var err error
+	conn, err = elastic.NewClient()
+	if err != nil {
+		// Handle error
+		panic(err)
+	}
+}
+
+// Conn returns a connection to ElasticSearch
+func Conn() *elastic.Client {
+	initOnce.Do(initConn)
+	return conn
+}

--- a/geo/bounding_box.go
+++ b/geo/bounding_box.go
@@ -1,0 +1,25 @@
+package geo
+
+// BoundingBox contains two sets of lat longs which represent a cube area
+type BoundingBox struct {
+	NW   Point
+	SE   Point
+	SRID int
+}
+
+// New returns a new BoundingBox from the given lat/long pairs
+func NewBoundingBox(nwLat float64, nwLon float64, seLat float64, seLon float64, srid int) (*BoundingBox, error) {
+	var bbBox BoundingBox
+	var err error
+
+	bbBox.NW, err = NewPoint(nwLon, nwLat, srid)
+	if err != nil {
+		return nil, err
+	}
+	bbBox.SE, err = NewPoint(seLon, seLat, srid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bbBox, nil
+}

--- a/geo/bounding_box.go
+++ b/geo/bounding_box.go
@@ -11,6 +11,7 @@ type BoundingBox struct {
 func NewBoundingBox(nwLat float64, nwLon float64, seLat float64, seLon float64, srid int) (*BoundingBox, error) {
 	var bbBox BoundingBox
 	var err error
+	bbBox.SRID = srid
 
 	bbBox.NW, err = NewPoint(nwLon, nwLat, srid)
 	if err != nil {

--- a/geo/centroid.go
+++ b/geo/centroid.go
@@ -1,0 +1,37 @@
+package geo
+
+import "math"
+
+// CalculateCentroid calculates a centroid based on an array of points
+func CalculateCentroid(coords []*Point) (float64, float64) {
+	x := float64(0)
+	y := float64(0)
+	z := float64(0)
+	for _, coord := range coords {
+		// degr to rad
+		lat := coord.Lat * math.Pi / 180
+		long := coord.Long * math.Pi / 180
+
+		// increment sums
+		x += math.Cos(lat) * math.Cos(long)
+		y += math.Cos(lat) * math.Sin(long)
+		z += math.Sin(lat)
+	}
+
+	// calculate averages
+	total := float64(len(coords))
+	x /= total
+	y /= total
+	z /= total
+
+	// average xyz to lat/long
+	cLong := math.Atan2(y, x)
+	cSqrt := math.Sqrt(x*x + y*y)
+	cLat := math.Atan2(z, cSqrt)
+
+	// rad back to degr
+	lat := cLat * 180 / math.Pi
+	long := cLong * 180 / math.Pi
+
+	return lat, long
+}

--- a/geo/point.go
+++ b/geo/point.go
@@ -1,0 +1,68 @@
+package point
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// Point represents a lat/long
+type Point struct {
+	Lat  float64
+	Long float64
+	SRID int
+}
+
+// New creates and returns a new Point
+func NewPoint(x float64, y float64, srid int) (*Point, error) {
+	return &Point{
+		Long: x,
+		Lat:  y,
+		SRID: srid,
+	}, nil
+}
+
+// IsNull returns a boolean indicating whether the point is considered null.
+// Currently returns true when the SRID has not been set.
+func (p Point) IsNull() bool {
+	return 0 == p.SRID
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (p Point) MarshalJSON() ([]byte, error) {
+	if p.IsNull() {
+		return []byte("null"), nil
+	}
+	return json.Marshal(map[string]float64{
+		"lat":  p.Lat,
+		"long": p.Long,
+	})
+}
+
+func (p Point) String() string {
+	if p.IsNull() {
+		return "NULL"
+	}
+	point := fmt.Sprintf(
+		"ST_GeometryFromText('POINT(%s %s)', %d)",
+		strconv.FormatFloat(p.Long, 'f', -1, 64),
+		strconv.FormatFloat(p.Lat, 'f', -1, 64),
+		p.SRID,
+	)
+	if p.SRID != WGS84 {
+		point = fmt.Sprintf("ST_Transform(%s,%d)", point, WGS84)
+	}
+	return point
+}
+
+// Compare returns true if the SRIDs of the given points are the same, and they
+// are located within "diff" distance of each other.
+// This is not a safe way to compare a lat/long in general, but for the NZ
+// coordinates we are dealing with it should work just fine.
+func (p Point) Compare(c Point, diff float64) bool {
+	if p.SRID != c.SRID {
+		return false
+	}
+	return math.Abs(p.Lat-c.Lat) < diff && math.Abs(p.Long-c.Long) < diff
+}

--- a/geo/srid.go
+++ b/geo/srid.go
@@ -1,0 +1,8 @@
+package geo
+
+const (
+	// WGS84 is an SRID
+	WGS84 = 4326
+	// NZTM is an SRID
+	NZTM = 2193
+)


### PR DESCRIPTION
Adds a simple elasticsearch package for setting up connections. This will likely need to be updated pretty soon :)

Also I have taken various bits of geo code from a few other repositories and glued them together to form the basis of a "geo" package. Hopefully this reduces repetition when creating point objects and such.