### PR TITLE
Use null.* methods instead of sql.* null methods

### DIFF
--- a/db/null_types.go
+++ b/db/null_types.go
@@ -1,6 +1,10 @@
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+
+	"gopkg.in/guregu/null.v3"
+)
 
 // ToNullString converts a string to a NullString, and sets Valid automatically
 func ToNullString(str string) sql.NullString {
@@ -11,4 +15,15 @@ func ToNullString(str string) sql.NullString {
 // if you want to set the value to be zero, it's recommended you set it by directly creating a sql.NullInt64.
 func ToNullInt64(i int64) sql.NullInt64 {
 	return sql.NullInt64{Int64: i, Valid: i != 0}
+}
+
+// StringFrom converts a string to a NullString, and sets Valid automatically
+func StringFrom(str string) null.String {
+	return null.NewString(str, str != "")
+}
+
+// IntFrom converts a int64 to a NullInt64, and sets Valid automatically. Note this will assume that 0 is a null,
+// if you want to set the value to be zero, it's recommended you use null.IntFrom instead.
+func IntFrom(i int64) null.Int {
+	return null.NewInt(i, i != 0)
 }

--- a/geo/bounding_box.go
+++ b/geo/bounding_box.go
@@ -2,12 +2,12 @@ package geo
 
 // BoundingBox contains two sets of lat longs which represent a cube area
 type BoundingBox struct {
-	NW   Point
-	SE   Point
+	NW   *Point
+	SE   *Point
 	SRID int
 }
 
-// New returns a new BoundingBox from the given lat/long pairs
+// NewBoundingBox returns a new BoundingBox from the given lat/long pairs
 func NewBoundingBox(nwLat float64, nwLon float64, seLat float64, seLon float64, srid int) (*BoundingBox, error) {
 	var bbBox BoundingBox
 	var err error

--- a/geo/point.go
+++ b/geo/point.go
@@ -1,4 +1,4 @@
-package point
+package geo
 
 import (
 	"encoding/json"
@@ -14,7 +14,7 @@ type Point struct {
 	SRID int
 }
 
-// New creates and returns a new Point
+// NewPoint creates and returns a new Point
 func NewPoint(x float64, y float64, srid int) (*Point, error) {
 	return &Point{
 		Long: x,


### PR DESCRIPTION
The null package methods support some extra stuff, including proper JSON serialization. This package is already used in a bunch of places, just introducing some helper methods for it.

https://godoc.org/gopkg.in/guregu/null.v3

Will add godeps after review.