### PR TITLE
Improve error handling in geo package

### DIFF
--- a/geo/bounding_box.go
+++ b/geo/bounding_box.go
@@ -8,24 +8,15 @@ type BoundingBox struct {
 }
 
 // NewBoundingBox returns a new BoundingBox from the given lat/long pairs
-func NewBoundingBox(nwLat float64, nwLon float64, seLat float64, seLon float64, srid int) (*BoundingBox, error) {
-	var bbBox BoundingBox
-	var err error
-	bbBox.SRID = srid
-
-	bbBox.NW, err = NewPoint(nwLon, nwLat, srid)
-	if err != nil {
-		return nil, err
+func NewBoundingBox(nwLat float64, nwLon float64, seLat float64, seLon float64, srid int) *BoundingBox {
+	return &BoundingBox{
+		NW:   NewPoint(nwLon, nwLat, srid),
+		SE:   NewPoint(seLon, seLat, srid),
+		SRID: srid,
 	}
-	bbBox.SE, err = NewPoint(seLon, seLat, srid)
-	if err != nil {
-		return nil, err
-	}
-
-	return &bbBox, nil
 }
 
 // Centroid calculates and returns the centroid of the bounding box
-func (bb BoundingBox) Centroid() (*Point, error) {
+func (bb BoundingBox) Centroid() *Point {
 	return CalculateCentroid([]*Point{bb.NW, bb.SE})
 }

--- a/geo/centroid.go
+++ b/geo/centroid.go
@@ -1,14 +1,11 @@
 package geo
 
-import (
-	"errors"
-	"math"
-)
+import "math"
 
 // CalculateCentroid calculates a centroid based on an array of points
-func CalculateCentroid(coords []*Point) (*Point, error) {
+func CalculateCentroid(coords []*Point) *Point {
 	if len(coords) == 0 {
-		return nil, errors.New("can't calculate centroid: no coordinates supplied")
+		return nil
 	}
 	x := float64(0)
 	y := float64(0)

--- a/geo/point.go
+++ b/geo/point.go
@@ -42,7 +42,7 @@ func NewPointLongAsLon(x float64, y float64, srid int) *Point {
 // IsNull returns a boolean indicating whether the point is considered null.
 // Currently returns true when the SRID has not been set.
 func (p Point) IsNull() bool {
-	return 0 == p.SRID
+	return p.SRID == 0 || p.Lat == 0 || p.Long == 0
 }
 
 // MarshalJSON implements the json.Marshaler interface

--- a/geo/point.go
+++ b/geo/point.go
@@ -21,22 +21,22 @@ type Point struct {
 }
 
 // NewPoint creates and returns a new Point
-func NewPoint(x float64, y float64, srid int) (*Point, error) {
+func NewPoint(x float64, y float64, srid int) *Point {
 	return &Point{
 		Long: x,
 		Lat:  y,
 		SRID: srid,
-	}, nil
+	}
 }
 
 // NewPointLongAsLon returns a new point with marshalLongAsLon set to true
-func NewPointLongAsLon(x float64, y float64, srid int) (*Point, error) {
+func NewPointLongAsLon(x float64, y float64, srid int) *Point {
 	return &Point{
 		Long:             x,
 		Lat:              y,
 		SRID:             srid,
 		marshalLongAsLon: true,
-	}, nil
+	}
 }
 
 // IsNull returns a boolean indicating whether the point is considered null.


### PR DESCRIPTION
- Point.IsNull() now returns true if any of Long/Lat/SRID fields are 0, rather than just SRID
- All error returns are removed. Was leading to over-complicated code at the other end for little gain.