### PR TITLE
Update nzAddress to handle hyphentated streetnumbers

### DIFF
--- a/nz_address/address.go
+++ b/nz_address/address.go
@@ -10,7 +10,7 @@ import (
 type Address struct {
 	UnitType        string `json:"unit_type"`
 	UnitIdentifier  string `json:"unit_identifier"`
-	StreetNumber    int    `json:"street_number"`
+	StreetNumber    string `json:"street_number"`
 	StreetAlpha     string `json:"street_alpha"`
 	StreetName      string `json:"street_name"`
 	StreetType      string `json:"street_type"`
@@ -57,14 +57,14 @@ func (a Address) Display() string {
 
 	var identifierStreet string
 	street := titleCase(a.Street())
-	if a.StreetNumber != 0 {
+	if a.StreetNumber != "" {
 		if a.UnitIdentifier != "" && a.BuildingName == "" {
 			if a.UnitType != "" {
 				identifierStreet += titleCase(a.UnitType) + " "
 			}
 			identifierStreet += strings.ToUpper(a.UnitIdentifier) + "/"
 		}
-		identifierStreet += strconv.Itoa(a.StreetNumber) + strings.ToUpper(a.StreetAlpha)
+		identifierStreet += a.StreetNumber + strings.ToUpper(a.StreetAlpha)
 		if street != "" {
 			identifierStreet += " "
 		}

--- a/nz_address/address_test.go
+++ b/nz_address/address_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Address", func() {
 			"a full set of address identifiers",
 			Address{
 				UnitIdentifier: "123",
-				StreetNumber:   5,
+				StreetNumber:   "5",
 				StreetAlpha:    "A",
 			},
 			"123/5A",
@@ -25,7 +25,7 @@ var _ = Describe("Address", func() {
 			Address{
 				UnitType:       "FLAT",
 				UnitIdentifier: "123",
-				StreetNumber:   5,
+				StreetNumber:   "5",
 				StreetAlpha:    "A",
 				StreetName:     "Cambridge",
 				StreetType:     "Terrace",
@@ -36,7 +36,7 @@ var _ = Describe("Address", func() {
 			"building name",
 			Address{
 				BuildingName: "Homes",
-				StreetNumber: 123,
+				StreetNumber: "123",
 				StreetName:   "Cambridge",
 				StreetType:   "Terrace",
 			},
@@ -45,7 +45,7 @@ var _ = Describe("Address", func() {
 		Entry(
 			"RD number",
 			Address{
-				StreetNumber: 123,
+				StreetNumber: "123",
 				StreetName:   "Cambridge",
 				StreetType:   "Terrace",
 				RDNumber:     "3c",
@@ -75,7 +75,7 @@ var _ = Describe("Address", func() {
 				BuildingName:   "Homes House",
 				UnitType:       "Unit",
 				UnitIdentifier: "5",
-				StreetNumber:   123,
+				StreetNumber:   "123",
 				StreetAlpha:    "B",
 				StreetName:     "CAMBRIDGE",
 				StreetType:     "TERRACE",
@@ -86,6 +86,15 @@ var _ = Describe("Address", func() {
 			},
 			"Unit 5 Homes House, 123B Cambridge Terrace, Brooklyn, RD 3A, Wellington",
 		),
+		Entry("hyphenated street number", Address{
+			UnitIdentifier: "4G",
+			StreetNumber:   "205-215",
+			StreetName:     "Hobson",
+			StreetType:     "Street",
+			City:           "Auckland",
+		},
+			"4G/205-215 Hobson Street, Auckland",
+		),
 	)
 	Describe("DisplayWithPostcode", func() {
 		It("appends postcode to the end of the display address", func() {
@@ -93,7 +102,7 @@ var _ = Describe("Address", func() {
 				BuildingName:   "Homes House",
 				UnitType:       "UNIT",
 				UnitIdentifier: "5",
-				StreetNumber:   123,
+				StreetNumber:   "123",
 				StreetAlpha:    "B",
 				StreetName:     "CAMBRIDGE",
 				StreetType:     "TERRACE",


### PR DESCRIPTION
This PR updates nzAddress to handle cases like `1b/205-215 Hobson Street, Auckland`.

To do this, we just change the type of street numbers to string