### PR TITLE
Feature/street number high

### DIFF
--- a/nz_address/address.go
+++ b/nz_address/address.go
@@ -10,7 +10,7 @@ import (
 type Address struct {
 	UnitType        string `json:"unit_type"`
 	UnitIdentifier  string `json:"unit_identifier"`
-	StreetNumber    string `json:"street_number"`
+	StreetNumber    int    `json:"street_number"`
 	StreetAlpha     string `json:"street_alpha"`
 	StreetName      string `json:"street_name"`
 	StreetType      string `json:"street_type"`
@@ -57,14 +57,14 @@ func (a Address) Display() string {
 
 	var identifierStreet string
 	street := titleCase(a.Street())
-	if a.StreetNumber != "" {
+	if a.StreetNumber != 0 {
 		if a.UnitIdentifier != "" && a.BuildingName == "" {
 			if a.UnitType != "" {
 				identifierStreet += titleCase(a.UnitType) + " "
 			}
 			identifierStreet += strings.ToUpper(a.UnitIdentifier) + "/"
 		}
-		identifierStreet += a.StreetNumber + strings.ToUpper(a.StreetAlpha)
+		identifierStreet += strconv.Itoa(a.StreetNumber) + strings.ToUpper(a.StreetAlpha)
 		if street != "" {
 			identifierStreet += " "
 		}

--- a/nz_address/address.go
+++ b/nz_address/address.go
@@ -8,15 +8,16 @@ import (
 // Address is a complete New Zealand address with all the required fields to
 // format into a human-readable address string.
 type Address struct {
-	UnitType        string `json:"unit_type"`
-	UnitIdentifier  string `json:"unit_identifier"`
-	StreetNumber    int    `json:"street_number"`
-	StreetAlpha     string `json:"street_alpha"`
-	StreetName      string `json:"street_name"`
-	StreetType      string `json:"street_type"`
-	StreetDirection string `json:"street_direction"`
-	Suburb          string `json:"suburb"`
-	City            string `json:"city"`
+	UnitType         string `json:"unit_type"`
+	UnitIdentifier   string `json:"unit_identifier"`
+	StreetNumber     int    `json:"street_number"`
+	StreetNumberHigh int    `json:"street_number_high"`
+	StreetAlpha      string `json:"street_alpha"`
+	StreetName       string `json:"street_name"`
+	StreetType       string `json:"street_type"`
+	StreetDirection  string `json:"street_direction"`
+	Suburb           string `json:"suburb"`
+	City             string `json:"city"`
 
 	BuildingName string `json:"building_name"`
 	Floor        string `json:"floor"`
@@ -65,6 +66,9 @@ func (a Address) Display() string {
 			identifierStreet += strings.ToUpper(a.UnitIdentifier) + "/"
 		}
 		identifierStreet += strconv.Itoa(a.StreetNumber) + strings.ToUpper(a.StreetAlpha)
+		if a.StreetNumberHigh != 0 {
+			identifierStreet += "-" + strconv.Itoa(a.StreetNumberHigh)
+		}
 		if street != "" {
 			identifierStreet += " "
 		}

--- a/nz_address/address_test.go
+++ b/nz_address/address_test.go
@@ -14,11 +14,29 @@ var _ = Describe("Address", func() {
 		Entry(
 			"a full set of address identifiers",
 			Address{
-				UnitIdentifier: "123",
-				StreetNumber:   5,
-				StreetAlpha:    "A",
+				UnitIdentifier:   "123",
+				StreetNumber:     5,
+				StreetAlpha:      "A",
+				StreetNumberHigh: 10,
 			},
-			"123/5A",
+			"123/5A-10",
+		),
+		Entry(
+			"street number range",
+			Address{
+				StreetNumber:     5,
+				StreetNumberHigh: 10,
+			},
+			"5-10",
+		),
+		Entry(
+			"street number range with unit identifier",
+			Address{
+				UnitIdentifier:   "123",
+				StreetNumber:     5,
+				StreetNumberHigh: 10,
+			},
+			"123/5-10",
 		),
 		Entry(
 			"a full set of address identifiers and street name/type",
@@ -72,19 +90,20 @@ var _ = Describe("Address", func() {
 		Entry(
 			"full address",
 			Address{
-				BuildingName:   "Homes House",
-				UnitType:       "Unit",
-				UnitIdentifier: "5",
-				StreetNumber:   123,
-				StreetAlpha:    "B",
-				StreetName:     "CAMBRIDGE",
-				StreetType:     "TERRACE",
-				RDNumber:       "3a",
-				Suburb:         "BROOKLYN",
-				City:           "WELLINGTON",
-				Postcode:       1234,
+				BuildingName:     "Homes House",
+				UnitType:         "Unit",
+				UnitIdentifier:   "5",
+				StreetNumber:     123,
+				StreetNumberHigh: 134,
+				StreetAlpha:      "B",
+				StreetName:       "CAMBRIDGE",
+				StreetType:       "TERRACE",
+				RDNumber:         "3a",
+				Suburb:           "BROOKLYN",
+				City:             "WELLINGTON",
+				Postcode:         1234,
 			},
-			"Unit 5 Homes House, 123B Cambridge Terrace, Brooklyn, RD 3A, Wellington",
+			"Unit 5 Homes House, 123B-134 Cambridge Terrace, Brooklyn, RD 3A, Wellington",
 		),
 	)
 	Describe("DisplayWithPostcode", func() {

--- a/nz_address/address_test.go
+++ b/nz_address/address_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Address", func() {
 			"a full set of address identifiers",
 			Address{
 				UnitIdentifier: "123",
-				StreetNumber:   "5",
+				StreetNumber:   5,
 				StreetAlpha:    "A",
 			},
 			"123/5A",
@@ -25,7 +25,7 @@ var _ = Describe("Address", func() {
 			Address{
 				UnitType:       "FLAT",
 				UnitIdentifier: "123",
-				StreetNumber:   "5",
+				StreetNumber:   5,
 				StreetAlpha:    "A",
 				StreetName:     "Cambridge",
 				StreetType:     "Terrace",
@@ -36,7 +36,7 @@ var _ = Describe("Address", func() {
 			"building name",
 			Address{
 				BuildingName: "Homes",
-				StreetNumber: "123",
+				StreetNumber: 123,
 				StreetName:   "Cambridge",
 				StreetType:   "Terrace",
 			},
@@ -45,7 +45,7 @@ var _ = Describe("Address", func() {
 		Entry(
 			"RD number",
 			Address{
-				StreetNumber: "123",
+				StreetNumber: 123,
 				StreetName:   "Cambridge",
 				StreetType:   "Terrace",
 				RDNumber:     "3c",
@@ -75,7 +75,7 @@ var _ = Describe("Address", func() {
 				BuildingName:   "Homes House",
 				UnitType:       "Unit",
 				UnitIdentifier: "5",
-				StreetNumber:   "123",
+				StreetNumber:   123,
 				StreetAlpha:    "B",
 				StreetName:     "CAMBRIDGE",
 				StreetType:     "TERRACE",
@@ -86,15 +86,6 @@ var _ = Describe("Address", func() {
 			},
 			"Unit 5 Homes House, 123B Cambridge Terrace, Brooklyn, RD 3A, Wellington",
 		),
-		Entry("hyphenated street number", Address{
-			UnitIdentifier: "4G",
-			StreetNumber:   "205-215",
-			StreetName:     "Hobson",
-			StreetType:     "Street",
-			City:           "Auckland",
-		},
-			"4G/205-215 Hobson Street, Auckland",
-		),
 	)
 	Describe("DisplayWithPostcode", func() {
 		It("appends postcode to the end of the display address", func() {
@@ -102,7 +93,7 @@ var _ = Describe("Address", func() {
 				BuildingName:   "Homes House",
 				UnitType:       "UNIT",
 				UnitIdentifier: "5",
-				StreetNumber:   "123",
+				StreetNumber:   123,
 				StreetAlpha:    "B",
 				StreetName:     "CAMBRIDGE",
 				StreetType:     "TERRACE",


### PR DESCRIPTION
Adds support for StreetNumberHigh field.

Reasoning: street number range is not a single value, it's two distinct values and should be treated as such. nzAddress's responsibility is to format a known address fields, not parse them - we have parsing packages for that.

This is in line with LINZ data.

Happy to discuss