### PR TITLE
Set content length on brickftp uploads

### DIFF
--- a/brickftp/brickftp.go
+++ b/brickftp/brickftp.go
@@ -110,11 +110,12 @@ func (c Client) StartUpload(name string) (*Upload, error) {
 
 // UploadPart uploads a file to the UploadURI given by Upload.
 // Max file size is 5GB per part
-func (c Client) UploadPart(u *Upload, r io.Reader) error {
+func (c Client) UploadPart(u *Upload, r io.Reader, contentLength int64) error {
 	req, err := http.NewRequest(http.MethodPut, u.UploadURI, r)
 	if err != nil {
 		return err
 	}
+	req.ContentLength = contentLength
 	res, err := c.doRequest(req, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Brickftp requires the content length to be set for uploads. In testing I had
used a bytes.Buffer which sets the content length automatically, this does
not happen for generic io.Readers. As per docs:

If body is of type *bytes.Buffer, *bytes.Reader, or *strings.Reader, the
returned request's ContentLength is set to its exact value (instead of
-1)