### PR TITLE
Add request logging middleware

### DIFF
--- a/config/logger.go
+++ b/config/logger.go
@@ -1,88 +1,12 @@
 package config
 
 import (
-	"os"
-
 	"github.com/HomesNZ/go-common/env"
-	"github.com/Sirupsen/logrus"
-	bugsnag "github.com/bugsnag/bugsnag-go"
-	bugsnagErrors "github.com/bugsnag/bugsnag-go/errors"
-	"github.com/pkg/errors"
+	"github.com/HomesNZ/go-common/logger"
 )
 
-// InitLogger initializes the logger by setting the log level to the env var LOG_LEVEL, or defaulting to `info`.
 func InitLogger() {
-	// If running in the production environment, output the logs as JSON format for parsing by Logstash.
-	if env.IsProd() {
-		logrus.SetFormatter(&logrus.JSONFormatter{})
-	}
-
-	logrus.SetOutput(os.Stdout)
-
-	level, err := logrus.ParseLevel(env.GetString("LOG_LEVEL", "info"))
-	// No need to handle the error here, just don't update the log level
-	if err == nil {
-		logrus.SetLevel(level)
-	}
-
-	// Hooks
-	logrus.AddHook(bugsnagHook{})
-
-	logrus.Infof("Log level: %s", logrus.GetLevel().String())
-}
-
-type bugsnagHook struct{}
-
-// Levels returns the logging levels that this hook will be fired for.
-func (b bugsnagHook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.ErrorLevel,
-		logrus.FatalLevel,
-		logrus.PanicLevel,
-	}
-}
-
-// skipFrames is the number of stack frames to skip in the error given to bugsnag
-const skipFrames = 4
-
-// Fire sends the logrus entry to bugsnag.
-func (b bugsnagHook) Fire(entry *logrus.Entry) error {
-	var err error
-	switch er := entry.Data[logrus.ErrorKey].(type) {
-	case stackTracer:
-		err = stackError{er}
-	case error:
-		err = er
-	default:
-		err = errors.New(entry.Message)
-	}
-	notify := bugsnagErrors.New(err, skipFrames)
-	meta := bugsnag.MetaData{}
-	for field, value := range entry.Data {
-		if field == logrus.ErrorKey {
-			continue
-		}
-		meta.Add("logrus", field, value)
-	}
-	return bugsnag.Notify(notify, meta)
-}
-
-type stackError struct {
-	stackTracer
-}
-
-var _ bugsnagErrors.ErrorWithCallers = stackError{}
-
-func (e stackError) Callers() []uintptr {
-	trace := e.StackTrace()
-	callers := make([]uintptr, len(trace))
-	for i, frame := range e.StackTrace() {
-		callers[i] = uintptr(frame)
-	}
-	return callers
-}
-
-type stackTracer interface {
-	error
-	StackTrace() errors.StackTrace
+	logger.Init(
+		logger.Level(env.GetString("LOG_LEVEL", "info")),
+	)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,96 @@
+package logger
+
+import (
+	"os"
+
+	"github.com/HomesNZ/go-common/env"
+	"github.com/Sirupsen/logrus"
+	bugsnag "github.com/bugsnag/bugsnag-go"
+	bugsnagErrors "github.com/bugsnag/bugsnag-go/errors"
+	"github.com/pkg/errors"
+)
+
+type Option func(*logrus.Logger)
+
+// Level option sets the log level
+func Level(level string) Option {
+	return func(logger *logrus.Logger) {
+		level, err := logrus.ParseLevel(level)
+		// No need to handle the error here, just don't update the log level
+		if err == nil {
+			logger.SetLevel(level)
+		}
+	}
+}
+
+// Init the global logger
+func Init(opts ...Option) *logrus.Logger {
+	logger := logrus.StandardLogger()
+	// If running in the production environment, output the logs as JSON format for parsing by Logstash.
+	if env.IsProd() {
+		logger.Formatter = &logrus.JSONFormatter{}
+	}
+	logger.Out = os.Stdout
+	logger.AddHook(bugsnagHook{})
+	for _, opt := range opts {
+		opt(logger)
+	}
+	logrus.Infof("Log level: %s", logrus.GetLevel().String())
+	return logger
+}
+
+type bugsnagHook struct{}
+
+// Levels returns the logging levels that this hook will be fired for.
+func (b bugsnagHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+// skipFrames is the number of stack frames to skip in the error given to bugsnag
+const skipFrames = 4
+
+// Fire sends the logrus entry to bugsnag.
+func (b bugsnagHook) Fire(entry *logrus.Entry) error {
+	var err error
+	switch er := entry.Data[logrus.ErrorKey].(type) {
+	case stackTracer:
+		err = stackError{er}
+	case error:
+		err = er
+	default:
+		err = errors.New(entry.Message)
+	}
+	notify := bugsnagErrors.New(err, skipFrames)
+	meta := bugsnag.MetaData{}
+	for field, value := range entry.Data {
+		if field == logrus.ErrorKey {
+			continue
+		}
+		meta.Add("logrus", field, value)
+	}
+	return bugsnag.Notify(notify, meta)
+}
+
+type stackError struct {
+	stackTracer
+}
+
+var _ bugsnagErrors.ErrorWithCallers = stackError{}
+
+func (e stackError) Callers() []uintptr {
+	trace := e.StackTrace()
+	callers := make([]uintptr, len(trace))
+	for i, frame := range e.StackTrace() {
+		callers[i] = uintptr(frame)
+	}
+	return callers
+}
+
+type stackTracer interface {
+	error
+	StackTrace() errors.StackTrace
+}

--- a/logger/logger_suite_test.go
+++ b/logger/logger_suite_test.go
@@ -1,0 +1,13 @@
+package logger_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logger Suite")
+}

--- a/logger/middleware.go
+++ b/logger/middleware.go
@@ -1,0 +1,68 @@
+package logger
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// name is the name of the application as recorded in latency metrics
+const name = "web"
+
+func getFirst(h http.Header, names ...string) string {
+	for _, name := range names {
+		if v := h.Get(name); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func Middleware(logger *logrus.Entry) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logged := &loggedResponseWriter{
+				ResponseWriter: w,
+				Status:         200,
+			}
+			defer func(begin time.Time) {
+				// Try to get the real IP
+				remoteAddr := r.RemoteAddr
+				if realIP := getFirst(r.Header, "X-Real-IP", "X-Forwarded-For"); realIP != "" {
+					remoteAddr = realIP
+				}
+				entry := logger.WithFields(logrus.Fields{
+					"request": r.RequestURI,
+					"method":  r.Method,
+					"remote":  remoteAddr,
+				})
+				if reqID := getFirst(r.Header, "X-Request-Id", "X-Amzn-Trace-Id"); reqID != "" {
+					entry = entry.WithField("request_id", reqID)
+				}
+				latency := time.Since(begin)
+				entry.WithFields(logrus.Fields{
+					"status":      logged.Status,
+					"text_status": http.StatusText(logged.Status),
+					"took":        latency,
+					fmt.Sprintf("measure#%s.latency", name): latency.Nanoseconds(),
+				}).Info("Handled request")
+			}(time.Now())
+
+			next.ServeHTTP(logged, r)
+		})
+	}
+}
+
+// loggedResponseWriter is a custom ResponseWriter that wraps http.ResponseWriter and also includes a status field for
+// logging.
+type loggedResponseWriter struct {
+	http.ResponseWriter
+	Status int
+}
+
+func (w *loggedResponseWriter) WriteHeader(statusCode int) {
+	w.Status = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}


### PR DESCRIPTION
Moves request logging into common logging package.

Reorganises global logging initialisation into new package and allow for configs to be injected.

Shouldn't be a breaking change