### PR TITLE
Refactor elasticsearch package to deprecate hidden state

### DIFF
--- a/elasticsearch/deprecated.go
+++ b/elasticsearch/deprecated.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/HomesNZ/go-common/env"
+	"github.com/Sirupsen/logrus"
 
 	"github.com/HomesNZ/elastic"
 	"github.com/smartystreets/go-aws-auth"
@@ -41,6 +42,9 @@ func initConn() {
 		// Handle error
 		panic(err)
 	}
+
+	logrus.WithField("package", "elasticsearch").
+		Info("elasticsearch.Conn() is deprecated, use .New() instead")
 }
 
 // Conn returns a connection to ElasticSearch

--- a/elasticsearch/deprecated.go
+++ b/elasticsearch/deprecated.go
@@ -44,7 +44,7 @@ func initConn() {
 	}
 
 	logrus.WithField("package", "elasticsearch").
-		Info("elasticsearch.Conn() is deprecated, use .New() instead")
+		Info("elasticsearch.Conn() is deprecated, use elastic.NewClient() instead")
 }
 
 // Conn returns a connection to ElasticSearch

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -7,15 +7,8 @@ import (
 	awsauth "github.com/smartystreets/go-aws-auth"
 )
 
-func New(cfg ...elastic.ClientOptionFunc) (*elastic.Client, error) {
-	// Set some defaults
-	options := []elastic.ClientOptionFunc{
-		elastic.SetSniff(false), // causes issues within AWS, so off by default
-	}
-
-	return elastic.NewClient(append(options, cfg...)...)
-}
-
+// AWSAccessKey configures the client to sign each outgoing request with AWS V4
+// signatures, using an IAM access key ID / secret key.
 func AWSAccessKey(accessKeyID, secretAccessKey string) elastic.ClientOptionFunc {
 	return elastic.SetPrepareRequest(func(req *http.Request) {
 		awsauth.Sign(req, awsauth.Credentials{
@@ -25,6 +18,8 @@ func AWSAccessKey(accessKeyID, secretAccessKey string) elastic.ClientOptionFunc 
 	})
 }
 
+// AWSSecurityToken configures the client to sign each outgoing request with AWS
+// V4 signatures, using a security token.
 func AWSSecurityToken(securityToken string) elastic.ClientOptionFunc {
 	return elastic.SetPrepareRequest(func(req *http.Request) {
 		awsauth.Sign(req, awsauth.Credentials{

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -18,8 +18,8 @@ func AWSAccessKey(accessKeyID, secretAccessKey string) elastic.ClientOptionFunc 
 	})
 }
 
-// AWSSecurityToken configures the client to sign each outgoing request with AWS
-// V4 signatures, using a security token.
+// AWSSecurityToken configures the client to use a security token to
+// authenticate with AWS.
 func AWSSecurityToken(securityToken string) elastic.ClientOptionFunc {
 	return elastic.SetPrepareRequest(func(req *http.Request) {
 		awsauth.Sign(req, awsauth.Credentials{

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -1,0 +1,34 @@
+package elasticsearch
+
+import (
+	"net/http"
+
+	"github.com/HomesNZ/elastic"
+	awsauth "github.com/smartystreets/go-aws-auth"
+)
+
+func New(cfg ...elastic.ClientOptionFunc) (*elastic.Client, error) {
+	// Set some defaults
+	options := []elastic.ClientOptionFunc{
+		elastic.SetSniff(false), // causes issues within AWS, so off by default
+	}
+
+	return elastic.NewClient(append(options, cfg...)...)
+}
+
+func AWSAccessKey(accessKeyID, secretAccessKey string) elastic.ClientOptionFunc {
+	return elastic.SetPrepareRequest(func(req *http.Request) {
+		awsauth.Sign(req, awsauth.Credentials{
+			AccessKeyID:     accessKeyID,
+			SecretAccessKey: secretAccessKey,
+		})
+	})
+}
+
+func AWSSecurityToken(securityToken string) elastic.ClientOptionFunc {
+	return elastic.SetPrepareRequest(func(req *http.Request) {
+		awsauth.Sign(req, awsauth.Credentials{
+			SecurityToken: securityToken,
+		})
+	})
+}


### PR DESCRIPTION
Remove the connection / init once pattern, we can just use elastic.New() instead. Also adds some helper functions for dealing with AWS authentication.