### PR TITLE
Add "RequestContext"

### DIFF
--- a/logger/middleware.go
+++ b/logger/middleware.go
@@ -11,15 +11,6 @@ import (
 // name is the name of the application as recorded in latency metrics
 const name = "web"
 
-func getFirst(h http.Header, names ...string) string {
-	for _, name := range names {
-		if v := h.Get(name); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
 func Middleware(logger *logrus.Entry) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -27,27 +18,20 @@ func Middleware(logger *logrus.Entry) func(http.Handler) http.Handler {
 				ResponseWriter: w,
 				Status:         200,
 			}
+			req := r.WithContext(populateRequestContext(r.Context(), r))
+
 			defer func(begin time.Time) {
-				// Try to get the real IP
-				remoteAddr := r.RemoteAddr
-				if realIP := getFirst(r.Header, "X-Real-IP", "X-Forwarded-For"); realIP != "" {
-					remoteAddr = realIP
-				}
-				entry := logger.WithFields(logrus.Fields{
-					"request": r.RequestURI,
-					"method":  r.Method,
-					"remote":  remoteAddr,
-				})
-				if reqID := getFirst(r.Header, "X-Request-Id", "X-Amzn-Trace-Id"); reqID != "" {
-					entry = entry.WithField("request_id", reqID)
-				}
 				latency := time.Since(begin)
-				entry.WithFields(logrus.Fields{
+				logger.WithFields(logrus.Fields{
+					"request":     r.RequestURI,
+					"method":      r.Method,
 					"status":      logged.Status,
 					"text_status": http.StatusText(logged.Status),
 					"took":        latency,
 					fmt.Sprintf("measure#%s.latency", name): latency.Nanoseconds(),
-				}).Info("Handled request")
+				}).
+					WithFields(FieldsFromContext(r.Context())).
+					Info("Handled request")
 			}(time.Now())
 
 			if f, ok := w.(http.Flusher); ok {
@@ -55,9 +39,9 @@ func Middleware(logger *logrus.Entry) func(http.Handler) http.Handler {
 					loggedResponseWriter: logged,
 					Flusher:              f,
 				}
-				next.ServeHTTP(&loggedFlusher, r)
+				next.ServeHTTP(&loggedFlusher, req)
 			} else {
-				next.ServeHTTP(&logged, r)
+				next.ServeHTTP(&logged, req)
 			}
 		})
 	}

--- a/logger/request_context.go
+++ b/logger/request_context.go
@@ -1,0 +1,60 @@
+package logger
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type contextKey int
+
+const (
+	ContextKeyRequestContext contextKey = iota
+)
+
+type RequestContext struct {
+	RemoteAddr string
+	RequestID  string
+}
+
+func FieldsFromContext(ctx context.Context) logrus.Fields {
+	rctx := retrieveRequestContext(ctx)
+
+	return logrus.Fields{
+		"remote":     rctx.RemoteAddr,
+		"request_id": rctx.RequestID,
+	}
+}
+
+func populateRequestContext(ctx context.Context, r *http.Request) context.Context {
+	remoteAddr := r.RemoteAddr
+	if realIP := getFirst(r.Header, "X-Real-IP", "X-Forwarded-For"); realIP != "" {
+		remoteAddr = realIP
+	}
+
+	requestContext := RequestContext{
+		RemoteAddr: remoteAddr,
+		RequestID:  getFirst(r.Header, "X-Request-Id", "X-Amzn-Trace-Id"),
+	}
+
+	return context.WithValue(ctx, ContextKeyRequestContext, requestContext)
+}
+
+func retrieveRequestContext(ctx context.Context) RequestContext {
+	rctx := ctx.Value(ContextKeyRequestContext)
+	if rctx == nil {
+		return RequestContext{}
+	}
+
+	return rctx.(RequestContext)
+}
+
+func getFirst(h http.Header, names ...string) string {
+	for _, name := range names {
+		if v := h.Get(name); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/logger/request_context_test.go
+++ b/logger/request_context_test.go
@@ -22,7 +22,8 @@ var _ = Describe("logger", func() {
 			r.Header.Set("X-Request-Id", reqID)
 			ctx := populateRequestContext(context.Background(), r)
 
-			rctx := retrieveRequestContext(ctx)
+			rctx, ok := retrieveRequestContext(ctx)
+			Expect(ok).To(BeTrue())
 			Expect(rctx.RemoteAddr).To(Equal(remoteAddr))
 			Expect(rctx.RequestID).To(Equal(reqID))
 		})
@@ -38,7 +39,8 @@ var _ = Describe("logger", func() {
 				r.Header.Set("X-Request-Id", reqID)
 				ctx := populateRequestContext(context.Background(), r)
 
-				rctx := retrieveRequestContext(ctx)
+				rctx, ok := retrieveRequestContext(ctx)
+				Expect(ok).To(BeTrue())
 				Expect(rctx.RemoteAddr).To(Equal(remoteAddr))
 				Expect(rctx.RequestID).To(Equal(reqID))
 			})
@@ -47,8 +49,9 @@ var _ = Describe("logger", func() {
 
 	Describe("retrieveRequestContext", func() {
 		It("returns an empty (but valid) context if not initialized", func() {
-			rctx := retrieveRequestContext(context.Background())
-			Expect(rctx).To(Equal(RequestContext{}))
+			rctx, ok := retrieveRequestContext(context.Background())
+			Expect(ok).To(BeFalse())
+			Expect(rctx).To(Equal(requestContext{}))
 		})
 	})
 

--- a/logger/request_context_test.go
+++ b/logger/request_context_test.go
@@ -1,0 +1,55 @@
+package logger
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("logger", func() {
+
+	Describe("populateRequestContext", func() {
+		It("returns a context including a RequestContext based on the given request", func() {
+			const (
+				remoteAddr = "127.0.0.1"
+				reqID      = "123"
+			)
+			r, err := http.NewRequest("GET", "https://homes.co.nz", http.NoBody)
+			Expect(err).ToNot(HaveOccurred())
+			r.RemoteAddr = remoteAddr
+			r.Header.Set("X-Request-Id", reqID)
+			ctx := populateRequestContext(context.Background(), r)
+
+			rctx := retrieveRequestContext(ctx)
+			Expect(rctx.RemoteAddr).To(Equal(remoteAddr))
+			Expect(rctx.RequestID).To(Equal(reqID))
+		})
+		Context("using X-Forwarded-For instead of remote addr", func() {
+			It("returns a context including a RequestContext based on the given request", func() {
+				const (
+					remoteAddr = "127.0.0.1"
+					reqID      = "123"
+				)
+				r, err := http.NewRequest("GET", "https://homes.co.nz", http.NoBody)
+				Expect(err).ToNot(HaveOccurred())
+				r.Header.Set("X-Forwarded-For", remoteAddr)
+				r.Header.Set("X-Request-Id", reqID)
+				ctx := populateRequestContext(context.Background(), r)
+
+				rctx := retrieveRequestContext(ctx)
+				Expect(rctx.RemoteAddr).To(Equal(remoteAddr))
+				Expect(rctx.RequestID).To(Equal(reqID))
+			})
+		})
+	})
+
+	Describe("retrieveRequestContext", func() {
+		It("returns an empty (but valid) context if not initialized", func() {
+			rctx := retrieveRequestContext(context.Background())
+			Expect(rctx).To(Equal(RequestContext{}))
+		})
+	})
+
+})


### PR DESCRIPTION
Goal is to easily be able to create loggers from a given context. Example:

```
log := logrus.WithFields(FieldsFromContext(ctx))

log.Info("hello world")
// output would include request ID, and remote IP address
```
