### PR TITLE
better error

### DIFF
--- a/brickftp/brickftp.go
+++ b/brickftp/brickftp.go
@@ -64,9 +64,8 @@ func (c Client) Move(oldName string, newName string) error {
 	if err != nil {
 		return err
 	}
-	const successStatus = http.StatusCreated
-	if res.StatusCode != successStatus {
-		return c.err("Move", "expected status %d, got: %d filename: %s", successStatus, res.StatusCode, oldName)
+	if (res.StatusCode < 200) && (res.StatusCode > 300) {
+		return c.err("Move", "expected status, got: %d filename: %s", res.StatusCode, oldName)
 	}
 	return nil
 }


### PR DESCRIPTION
https://homescon.atlassian.net/browse/MI-1773
This function returns error when brickftp returns 204. I assume that Data Import just ignores that.
magic constants to cover all success codes ...