### PR TITLE
Add application name to db requests

### DIFF
--- a/db/connection.go
+++ b/db/connection.go
@@ -81,7 +81,7 @@ func (db *PG) Open(service string) {
 
 	db.Conn = c
 
-	err = db.verifyConnection()
+	err = db.verifyConnection(service)
 	if err != nil {
 		log.WithError(err).Fatal(ErrUnableToConnectToDB)
 	}
@@ -89,8 +89,8 @@ func (db *PG) Open(service string) {
 
 // verifyConnection pings the database to verify a connection is established. If the connection cannot be established,
 // it will retry with an exponential back off.
-func (db PG) verifyConnection() error {
-	log.Infof("Attempting to connect to database: %s", db.logSafeConnectionString("go-common"))
+func (db PG) verifyConnection(service string) error {
+	log.Infof("Attempting to connect to database: %s", db.logSafeConnectionString(service))
 
 	pingDB := func() error {
 		return db.Conn.Ping()

--- a/db/connection_internal_test.go
+++ b/db/connection_internal_test.go
@@ -21,8 +21,8 @@ var _ = Describe("PG", func() {
 			It("adds the search_path parameter", func() {
 				db := PG{}
 
-				actual := db.logSafeConnectionString()
-				expected := "postgres://user:****@host:5432/test?sslmode=disable&search_path=public"
+				actual := db.logSafeConnectionString("go-common")
+				expected := "postgres://user:****@host:5432/test?sslmode=disable&application_name=go-common&search_path=public"
 
 				Expect(actual).To(Equal(expected))
 			})
@@ -34,8 +34,8 @@ var _ = Describe("PG", func() {
 
 				db := PG{}
 
-				actual := db.logSafeConnectionString()
-				expected := "postgres://user:****@host:5432/test?sslmode=disable"
+				actual := db.logSafeConnectionString("go-common")
+				expected := "postgres://user:****@host:5432/test?sslmode=disable&application_name=go-common"
 
 				Expect(actual).To(Equal(expected))
 			})
@@ -45,8 +45,8 @@ var _ = Describe("PG", func() {
 			It("replaces the password with stars", func() {
 				db := PG{}
 
-				actual := db.logSafeConnectionString()
-				expected := "postgres://user:****@host:5432/test?sslmode=disable"
+				actual := db.logSafeConnectionString("go-common")
+				expected := "postgres://user:****@host:5432/test?sslmode=disable&application_name=go-common"
 
 				Expect(actual).To(Equal(expected))
 			})
@@ -58,8 +58,8 @@ var _ = Describe("PG", func() {
 
 				db := PG{}
 
-				actual := db.logSafeConnectionString()
-				expected := db.connectionString()
+				actual := db.logSafeConnectionString("go-common")
+				expected := db.connectionString("go-common")
 
 				Expect(actual).To(Equal(expected))
 			})

--- a/db/orm.go
+++ b/db/orm.go
@@ -20,8 +20,8 @@ var (
 )
 
 // InitORM initializes the ORM connection from the existing connection.
-func InitORM() {
-	g, err := gorm.Open("postgres", Conn())
+func InitORM(service string) {
+	g, err := gorm.Open("postgres", Conn(service))
 	if err != nil {
 		// This shouldnt happen unless our DB settings are malformed?
 		panic(err)
@@ -35,11 +35,11 @@ func InitORM() {
 }
 
 // ORM is the gorm wrapped SQL database connection. If the connection is nil, it will be initialized.
-func ORM() *gorm.DB {
+func ORM(service string) *gorm.DB {
 	UseORM = true
 
-	once.Do(InitConnection)
-	ormOnce.Do(InitORM)
+	once.Do(func() { InitConnection(service) })
+	ormOnce.Do(func() { InitORM(service) })
 	return orm
 }
 

--- a/db/redshift.go
+++ b/db/redshift.go
@@ -45,9 +45,9 @@ func SetConnectionRedshift(db *sql.DB) {
 type RS PG
 
 // ConnRedshift is the SQL database connection accessor. If the connection is nil, it will be initialized.
-func ConnRedshift() *sql.DB {
+func ConnRedshift(service string) *sql.DB {
 	if connRedshift == nil {
-		onceRedshift.Do(InitConnection)
+		onceRedshift.Do(func() { InitConnection(service) })
 	}
 	return connRedshift
 }


### PR DESCRIPTION
Adds application_name to the postgresql conn string.

This parameter sets the value of `Application` which is used to determine which caller triggered a given query.

This is a breaking change which will require an update to all usages of db.Conn().

https://www.postgresql.org/docs/11/libpq-connect.html