### PR TITLE
Add placeholder generation method to dbClient

### DIFF
--- a/dbclient/placeholders.go
+++ b/dbclient/placeholders.go
@@ -1,0 +1,60 @@
+package dbclient
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// Placeholders converts a given slice of interfaces into a set of postgresql insertion instructions
+func Placeholders(rawArgs []interface{}) (string, [][]interface{}) {
+	if len(rawArgs) == 0 {
+		return "", nil
+	}
+	args := extractArgs(rawArgs)
+	return generatePlaceholders(args), args
+}
+
+// extractArgs converts a slice of structs to a slice of slices containing the public fields of the given structs
+func extractArgs(args []interface{}) [][]interface{} {
+	var sqlArgs [][]interface{}
+
+	for _, arg := range args {
+		var fields []interface{}
+		v := reflect.ValueOf(arg)
+		for i := 0; i < v.NumField(); i++ {
+			a := v.Field(i)
+			if !a.CanInterface() {
+				continue
+			}
+			fields = append(fields, a.Interface())
+		}
+
+		sqlArgs = append(sqlArgs, fields)
+	}
+
+	return sqlArgs
+}
+
+func generatePlaceholders(args [][]interface{}) string {
+	b := strings.Builder{}
+	total := 1
+	for i, arg := range args {
+		b.WriteString("(")
+		var placeholders []string
+
+		for j := range arg {
+			placeholders = append(placeholders, "$"+strconv.Itoa(total+j))
+		}
+
+		b.WriteString(strings.Join(placeholders, ","))
+		b.WriteString(")")
+		total += len(arg)
+		// if not last element, add ','
+		if i+1 < len(args) {
+			b.WriteString(",")
+		}
+	}
+
+	return b.String()
+}

--- a/dbclient/placeholders.go
+++ b/dbclient/placeholders.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// SQL_MAX_PLACEHOLDERS is the maximum number of placeholder arguments that postgresql will allow in a single query
+// This is based on the error message returned from overloading this number `PostgreSQL supports maximum of 65535 parameters`
+// and on a stackoverflow comment https://github.com/brianc/node-postgres/issues/1463#issuecomment-333313948
 const SQL_MAX_PLACEHOLDERS = 65535
 
 type Placeholder struct {

--- a/dbclient/placeholders.go
+++ b/dbclient/placeholders.go
@@ -18,15 +18,17 @@ func Placeholders(rawArgs []interface{}) []Placeholder {
 	if len(rawArgs) == 0 {
 		return nil
 	}
+
 	var placeholders []Placeholder
-	for i := 0; len(rawArgs) < (i+1)*SQL_MAX_PLACEHOLDERS; i++ {
-		from := i * SQL_MAX_PLACEHOLDERS
-		to := (i + 1) * SQL_MAX_PLACEHOLDERS
-		if to > len(rawArgs) {
+	fields := reflect.ValueOf(rawArgs[0]).NumField()
+	batchSize := SQL_MAX_PLACEHOLDERS / fields
+	for i := 0; i < len(rawArgs); i += batchSize {
+		to := i + batchSize
+		if len(rawArgs) < to {
 			to = len(rawArgs) - 1
 		}
 
-		structArgs := extractArgs(rawArgs[from:to])
+		structArgs := extractArgs(rawArgs[i:to])
 		placeholders = append(placeholders, Placeholder{
 			Placeholders: generatePlaceholders(structArgs),
 			Args:         flattenArgs(structArgs),

--- a/dbclient/placeholders.go
+++ b/dbclient/placeholders.go
@@ -10,7 +10,7 @@ const SQL_MAX_PLACEHOLDERS = 65535
 
 type Placeholder struct {
 	Placeholders string
-	Args         [][]interface{}
+	Args         []interface{}
 }
 
 // Placeholders converts a given slice of interfaces into a set of postgresql insertion instructions
@@ -26,14 +26,24 @@ func Placeholders(rawArgs []interface{}) []Placeholder {
 			to = len(rawArgs) - 1
 		}
 
-		args := extractArgs(rawArgs[from:to])
+		structArgs := extractArgs(rawArgs[from:to])
 		placeholders = append(placeholders, Placeholder{
-			Placeholders: generatePlaceholders(args),
-			Args:         args,
+			Placeholders: generatePlaceholders(structArgs),
+			Args:         flattenArgs(structArgs),
 		})
 	}
 
 	return placeholders
+}
+
+func flattenArgs(args [][]interface{}) []interface{} {
+	var flattened []interface{}
+	for _, arr := range args {
+		for _, v := range arr {
+			flattened = append(flattened, v)
+		}
+	}
+	return flattened
 }
 
 // extractArgs converts a slice of structs to a slice of slices containing the public fields of the given structs

--- a/dbclient/placeholders_test.go
+++ b/dbclient/placeholders_test.go
@@ -1,0 +1,148 @@
+package dbclient
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func Test_generatePlaceholders(t *testing.T) {
+	type args struct {
+		args [][]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "generates valid placeholders for 1 length slice without internal commas",
+			args: args{
+				args: [][]interface{}{
+					{struct{ Foo string }{"a"}},
+				},
+			},
+			want: "($1)",
+		},
+		{
+			name: "generates valid placeholders for 3 length slice without internal commas",
+			args: args{
+				args: [][]interface{}{
+					{struct{ Foo string }{"a"}},
+					{struct{ Foo string }{"b"}},
+					{struct{ Foo string }{"c"}},
+				},
+			},
+			want: "($1),($2),($3)",
+		},
+		{
+			name: "generates valid placeholders for 3 length slice",
+			args: args{
+				args: [][]interface{}{
+					{struct{ Foo string }{"a"}, struct{ Foo string }{"A"}},
+					{struct{ Foo string }{"b"}, struct{ Foo string }{"B"}},
+					{struct{ Foo string }{"c"}, struct{ Foo string }{"C"}},
+				},
+			},
+			want: "($1,$2),($3,$4),($5,$6)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generatePlaceholders(tt.args.args); got != tt.want {
+				t.Errorf("generatePlaceholders() = \"%v\", want \"%v\"", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractArgs(t *testing.T) {
+	type args struct {
+		args []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]interface{}
+	}{
+		{
+			name: "generates valid args for 1 length slice",
+			args: args{
+				args: []interface{}{
+					struct{ Foo string }{"a"},
+				},
+			},
+			want: [][]interface{}{
+				{"a"},
+			},
+		},
+		{
+			name: "generates valid placeholders for 3 slices of 1 length",
+			args: args{
+				args: []interface{}{
+					struct{ Foo string }{"a"},
+					struct{ Foo string }{"b"},
+					struct{ Foo string }{"c"},
+				},
+			},
+			want: [][]interface{}{
+				{"a"},
+				{"b"},
+				{"c"},
+			},
+		},
+		{
+			name: "generates valid placeholders for 3 slices of 2 length",
+			args: args{
+				args: []interface{}{
+					struct{ Foo, Bar string }{"a", "A"},
+					struct{ Foo, Bar string }{"b", "B"},
+					struct{ Foo, Bar string }{"c", "C"},
+				},
+			},
+			want: [][]interface{}{
+				{"a", "A"},
+				{"b", "B"},
+				{"c", "C"},
+			},
+		},
+		{
+			name: "generates valid placeholders for 3 slices of 2 length, ignoring private fields",
+			args: args{
+				args: []interface{}{
+					struct{ Foo, Bar, baz string }{"a", "A", "e"},
+					struct{ Foo, Bar, baz string }{"b", "B", "e"},
+					struct{ Foo, Bar, baz string }{"c", "C", "e"},
+				},
+			},
+			want: [][]interface{}{
+				{"a", "A"},
+				{"b", "B"},
+				{"c", "C"},
+			},
+		},
+		{
+			name: "generates valid placeholders for 3 slices of 2 length, ignoring internal private fields",
+			args: args{
+				args: []interface{}{
+					struct{ Foo, baz, Bar string }{"a", "e", "A"},
+					struct{ Foo, baz, Bar string }{"b", "e", "B"},
+					struct{ Foo, baz, Bar string }{"c", "e", "C"},
+				},
+			},
+			want: [][]interface{}{
+				{"a", "A"},
+				{"b", "B"},
+				{"c", "C"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractArgs(tt.args.args); !reflect.DeepEqual(got, tt.want) {
+				fmt.Println(got)
+				t.Errorf("extractArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/dbclient/placeholders_test.go
+++ b/dbclient/placeholders_test.go
@@ -1,7 +1,6 @@
 package dbclient
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -15,6 +14,13 @@ func Test_generatePlaceholders(t *testing.T) {
 		args args
 		want string
 	}{
+		{
+			name: "generates valid placeholders for 0 length slice",
+			args: args{
+				args: [][]interface{}{},
+			},
+			want: "",
+		},
 		{
 			name: "generates valid placeholders for 1 length slice without internal commas",
 			args: args{
@@ -65,6 +71,13 @@ func Test_extractArgs(t *testing.T) {
 		args args
 		want [][]interface{}
 	}{
+		{
+			name: "generates valid args for 0 length slice",
+			args: args{
+				args: []interface{}{},
+			},
+			want: [][]interface{}(nil),
+		},
 		{
 			name: "generates valid args for 1 length slice",
 			args: args{
@@ -140,8 +153,7 @@ func Test_extractArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := extractArgs(tt.args.args); !reflect.DeepEqual(got, tt.want) {
-				fmt.Println(got)
-				t.Errorf("extractArgs() = %v, want %v", got, tt.want)
+				t.Errorf("extractArgs() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds a public method for converting arbitrary structs into valid postgresql insert placeholders