### PR TITLE
Add init method for open tracing

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,32 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/exporters/trace/jaeger"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func initTracer(ctx context.Context, serviceName, collectorHost, collectorPort, collectorPath string) (func(), error) {
+	collectorEndpoint := fmt.Sprintf("http://%s:%s%s", collectorHost, collectorPort, collectorPath)
+	flush, err := jaeger.InstallNewPipeline(
+		jaeger.WithCollectorEndpoint(collectorEndpoint),
+		jaeger.WithProcess(jaeger.Process{
+			ServiceName: serviceName,
+		}),
+		jaeger.WithSDK(&trace.Config{DefaultSampler: trace.AlwaysSample()}),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "InstallNewPipeline")
+	}
+
+	tr := global.Tracer("init")
+	_, span := tr.Start(ctx, "init")
+	defer span.End()
+	time.Sleep(1 * time.Second)
+	return flush, nil
+}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -32,7 +32,7 @@ func TracerConfigFromEnv() (*TracerConfig, error) {
 }
 
 // InitTracer adds a standard Jaeger Tracer to the otel global API
-func InitTracer(ctx context.Context, cfg TracerConfig, sampleType trace.Sampler) (func(), error) {
+func InitTracer(ctx context.Context, cfg *TracerConfig, sampleType trace.Sampler) (func(), error) {
 	flush, err := jaeger.InstallNewPipeline(
 		jaeger.WithCollectorEndpoint(cfg.CollectorEndpoint),
 		jaeger.WithProcess(jaeger.Process{

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -51,7 +51,7 @@ func InitTracer(ctx context.Context, cfg *TracerConfig, sampleType trace.Sampler
 
 	global.SetTextMapPropagator(otel.NewCompositeTextMapPropagator(propagators.TraceContext{}, propagators.Baggage{}))
 	http.DefaultClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
-	http.DefaultTransport = &otelhttp.NewTransport(http.DefaultTransport)
+	http.DefaultTransport = http.DefaultClient.Transport
 
 	tr := global.Tracer("init")
 	_, span := tr.Start(ctx, "init")

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -11,8 +11,15 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+type TracerConfig struct {
+	Name          string
+	CollectorHost string
+	CollectorPort string
+	CollectorPath string
+}
+
 // InitTracer adds a standard Jaeger Tracer to the otel global API
-func InitTracer(ctx context.Context, serviceName, collectorHost, collectorPort, collectorPath string) (func(), error) {
+func InitTracer(ctx context.Context) (func(), error) {
 	collectorEndpoint := fmt.Sprintf("http://%s:%s%s", collectorHost, collectorPort, collectorPath)
 	flush, err := jaeger.InstallNewPipeline(
 		jaeger.WithCollectorEndpoint(collectorEndpoint),

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -51,6 +51,7 @@ func InitTracer(ctx context.Context, cfg *TracerConfig, sampleType trace.Sampler
 
 	global.SetTextMapPropagator(otel.NewCompositeTextMapPropagator(propagators.TraceContext{}, propagators.Baggage{}))
 	http.DefaultClient = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	http.DefaultTransport = &otelhttp.NewTransport(http.DefaultTransport)
 
 	tr := global.Tracer("init")
 	_, span := tr.Start(ctx, "init")

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -11,7 +11,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
-func initTracer(ctx context.Context, serviceName, collectorHost, collectorPort, collectorPath string) (func(), error) {
+// InitTracer adds a standard Jaeger Tracer to the otel global API
+func InitTracer(ctx context.Context, serviceName, collectorHost, collectorPort, collectorPath string) (func(), error) {
 	collectorEndpoint := fmt.Sprintf("http://%s:%s%s", collectorHost, collectorPort, collectorPath)
 	flush, err := jaeger.InstallNewPipeline(
 		jaeger.WithCollectorEndpoint(collectorEndpoint),

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/HomesNZ/env"
 	"github.com/pkg/errors"
@@ -56,6 +55,5 @@ func InitTracer(ctx context.Context, cfg *TracerConfig, sampleType trace.Sampler
 	tr := global.Tracer("init")
 	_, span := tr.Start(ctx, "init")
 	defer span.End()
-	time.Sleep(1 * time.Second)
 	return flush, nil
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -35,13 +35,13 @@ func TracerConfigFromEnv() TracerConfig {
 }
 
 // InitTracer adds a standard Jaeger Tracer to the otel global API
-func InitTracer(ctx context.Context, cfg TracerConfig) (func(), error) {
+func InitTracer(ctx context.Context, cfg TracerConfig, sampleType trace.Sampler) (func(), error) {
 	flush, err := jaeger.InstallNewPipeline(
 		jaeger.WithCollectorEndpoint(cfg.collectorEndpoint()),
 		jaeger.WithProcess(jaeger.Process{
 			ServiceName: cfg.Name,
 		}),
-		jaeger.WithSDK(&trace.Config{DefaultSampler: trace.AlwaysSample()}),
+		jaeger.WithSDK(&trace.Config{DefaultSampler: sampleType}),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "InstallNewPipeline")


### PR DESCRIPTION
based on https://github.com/open-telemetry/opentelemetry-go

This PR adds a function to initialise open tracing with Jaeger. In particular this opens a new jaeger pipeline and adds it to otels global tracer provider.

Currently requires:
```
	go.opentelemetry.io/otel v0.13.0
	go.opentelemetry.io/otel/exporters/trace/jaeger v0.13.0
	go.opentelemetry.io/otel/sdk v0.13.0
```

This should be used in combination with a middleware like `go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux` or
`https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/gin-gonic/gin/otelgin`
To trivially add tracing to http requests