### PR TITLE
fix/lambda cold start

### DIFF
--- a/dbclient/README.md
+++ b/dbclient/README.md
@@ -1,0 +1,25 @@
+# dbclient/v4
+
+This package provides a client for interacting with a PostgreSQL database using the pgxpool package.
+
+# Usage
+
+To use this package, you need to import it in your Go code:
+```
+import "github.com/HomesNZ/go-common/dbclient/v4"
+```
+
+Then, you can create a new database client useing `New` or `NewFromEnv`
+
+# Configuration
+The Connect function takes a *config.Config parameter which is used to configure the database connection. Here are the available configuration options:
+
+DB_HOST: The host of the database.
+DB_USER: The user to connect to the database.
+DB_NAME: The name of the database.
+DB_PASSWORD: The password to connect to the database.
+DB_PORT: The port of the database. // default 5432
+DB_MAX_CONNECT: The maximum number of connections in the pool. // default 3
+DB_HEALTH_CHECK_PERIOD: seconds - how often to check health of the connection // default 30
+DB_MAX_CONN_IDLE_TIME: mins - how long connection can be idle before it'll be closed // default 5
+DB_PING_BEFORE_USE:  if true, t'll be used to check connection before use and if the connection is not alive, it'll be reconnected

--- a/dbclient/v4/config/config.go
+++ b/dbclient/v4/config/config.go
@@ -1,31 +1,40 @@
 package config
 
 import (
+	"time"
+
 	"github.com/HomesNZ/go-common/env"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 type Config struct {
-	ServiceName string
-	Host        string
-	User        string
-	Name        string
-	Password    string
-	MaxConns    int
-	Port        int
-	SearchPath  string
+	ServiceName       string
+	Host              string
+	User              string
+	Name              string
+	Password          string
+	MaxConns          int
+	Port              int
+	SearchPath        string
+	HealthCheckPeriod time.Duration // seconds
+	MaxConnIdleTime   time.Duration // minutes
 }
 
 func NewFromEnv() *Config {
+	healthCheckPeriod := time.Duration(env.GetInt("DB_HEALTH_CHECK_PERIOD", 30)) * time.Second
+	maxConnIdleTime := time.Duration(env.GetInt("DB_MAX_CONN_IDLE_TIME", 5)) * time.Minute
+
 	cfg := &Config{
-		ServiceName: env.GetString("SERVICE_NAME", ""),
-		Host:        env.GetString("DB_HOST", "localhost"),
-		User:        env.GetString("DB_USER", "postgres"),
-		Name:        env.GetString("DB_NAME", ""),
-		Password:    env.GetString("DB_PASSWORD", ""),
-		MaxConns:    env.GetInt("DB_MAX_CONNECT", 1),
-		Port:        env.GetInt("DB_PORT", 5432),
-		SearchPath:  env.GetString("DB_SEARCH_PATH", ""),
+		ServiceName:       env.GetString("SERVICE_NAME", ""),
+		Host:              env.GetString("DB_HOST", "localhost"),
+		User:              env.GetString("DB_USER", "postgres"),
+		Name:              env.GetString("DB_NAME", ""),
+		Password:          env.GetString("DB_PASSWORD", ""),
+		MaxConns:          env.GetInt("DB_MAX_CONNECT", 3),
+		Port:              env.GetInt("DB_PORT", 5432),
+		SearchPath:        env.GetString("DB_SEARCH_PATH", ""),
+		HealthCheckPeriod: healthCheckPeriod,
+		MaxConnIdleTime:   maxConnIdleTime,
 	}
 
 	return cfg

--- a/dbclient/v4/config/config.go
+++ b/dbclient/v4/config/config.go
@@ -13,16 +13,18 @@ type Config struct {
 	User              string
 	Name              string
 	Password          string
-	MaxConns          int
+	MaxConns          int // max number of connections in the pool. will define
 	Port              int
 	SearchPath        string
-	HealthCheckPeriod time.Duration // seconds
-	MaxConnIdleTime   time.Duration // minutes
+	HealthCheckPeriod time.Duration // seconds - how often to check health of the connection
+	MaxConnIdleTime   time.Duration // minutes - how long connection can be idle before it'll be closed
+	PingBeforeUse     bool          // it'll be used to check connection before use, if true and connection is not alive, it'll be reconnected
 }
 
 func NewFromEnv() *Config {
 	healthCheckPeriod := time.Duration(env.GetInt("DB_HEALTH_CHECK_PERIOD", 30)) * time.Second
 	maxConnIdleTime := time.Duration(env.GetInt("DB_MAX_CONN_IDLE_TIME", 5)) * time.Minute
+	pingBeforeUse := env.GetBool("DB_PING_BEFORE_USE", true)
 
 	cfg := &Config{
 		ServiceName:       env.GetString("SERVICE_NAME", ""),
@@ -35,6 +37,7 @@ func NewFromEnv() *Config {
 		SearchPath:        env.GetString("DB_SEARCH_PATH", ""),
 		HealthCheckPeriod: healthCheckPeriod,
 		MaxConnIdleTime:   maxConnIdleTime,
+		PingBeforeUse:     pingBeforeUse,
 	}
 
 	return cfg

--- a/dbclient/v4/dbclient.go
+++ b/dbclient/v4/dbclient.go
@@ -3,6 +3,7 @@ package dbclient
 import (
 	"context"
 	"fmt"
+
 	"github.com/jackc/pgx/v4"
 
 	"github.com/HomesNZ/go-common/dbclient/v4/config"
@@ -62,10 +63,12 @@ func connectionConfig(cfg *config.Config) (*pgxpool.Config, error) {
 	config.HealthCheckPeriod = cfg.HealthCheckPeriod
 	config.MaxConnIdleTime = cfg.MaxConnIdleTime
 
-	// BeforeAcquire is called before a connection is acquired from the pool.
-	// If it returns false, the connection is discarded and a new connection is acquired.
-	config.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool {
-		return conn.Ping(ctx) == nil
+	if cfg.PingBeforeUse {
+		// BeforeAcquire is called before a connection is acquired from the pool.
+		// If it returns false, the connection is discarded and a new connection is acquired.
+		config.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool {
+			return conn.Ping(ctx) == nil
+		}
 	}
 
 	return config, nil

--- a/dbclient/v4/dbclient.go
+++ b/dbclient/v4/dbclient.go
@@ -3,6 +3,7 @@ package dbclient
 import (
 	"context"
 	"fmt"
+	"github.com/jackc/pgx/v4"
 
 	"github.com/HomesNZ/go-common/dbclient/v4/config"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -53,6 +54,19 @@ func connectionConfig(cfg *config.Config) (*pgxpool.Config, error) {
 	}
 
 	config, err := pgxpool.ParseConfig(connStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "db failed to parse config")
+	}
 	config.ConnConfig.PreferSimpleProtocol = true
-	return config, errors.Wrap(err, "DB failed to parse config")
+
+	config.HealthCheckPeriod = cfg.HealthCheckPeriod
+	config.MaxConnIdleTime = cfg.MaxConnIdleTime
+
+	// BeforeAcquire is called before a connection is acquired from the pool.
+	// If it returns false, the connection is discarded and a new connection is acquired.
+	config.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool {
+		return conn.Ping(ctx) == nil
+	}
+
+	return config, nil
 }


### PR DESCRIPTION
`BeforeAcquire` hook has to help with AWS lambda cold start. It looks like that AWS Lambda closes all connection. BeforeAcquire checks if a connection is valid, if not it'll acquire a new one