### PR TITLE
ASB-5926: Move log handler log to debug level

### DIFF
--- a/logger/middleware.go
+++ b/logger/middleware.go
@@ -44,7 +44,7 @@ func Middleware(logger *logrus.Entry) func(http.Handler) http.Handler {
 					"text_status":                           http.StatusText(status),
 					"took":                                  latency,
 					fmt.Sprintf("measure#%s.latency", name): latency.Nanoseconds(),
-				}).Info("Handled request")
+				}).Debug("Handled request")
 			}(time.Now())
 
 			var logged http.ResponseWriter = &loggedResponseWriter{


### PR DESCRIPTION
The `Handled request` log makes up about 80% of all Homes log traffic to Splunk.
Moving it to debug, and not logging it most of the time, should save ~USD1600/month